### PR TITLE
Added bot detection bundle to prevent link checkers from triggering a double opt in

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
     "psr/log": "^2.0 || ^3.0",
     "terminal42/contao-leads": "^3.0",
     "terminal42/notification_center": "^2.0",
+    "bugbuster/contao-botdetection-bundle": "^1.8",
     "ext-mbstring": "*"
   },
   "require-dev": {

--- a/config/di.yml
+++ b/config/di.yml
@@ -12,7 +12,6 @@ services:
          $translator: '@translator'
          $expressionLanguage: '@terminal42_leads.expression_language'
          $tokenDefinitionFactory: '@Terminal42\NotificationCenterBundle\Token\Definition\Factory\TokenDefinitionFactoryInterface'
-         $botDetection: '@BugBuster\BotDetection\ModuleBotDetection'
 
    Cgoit\LeadsOptinBundle\:
       resource: ../src/*

--- a/config/di.yml
+++ b/config/di.yml
@@ -12,6 +12,7 @@ services:
          $translator: '@translator'
          $expressionLanguage: '@terminal42_leads.expression_language'
          $tokenDefinitionFactory: '@Terminal42\NotificationCenterBundle\Token\Definition\Factory\TokenDefinitionFactoryInterface'
+         $botDetection: '@BugBuster\BotDetection\ModuleBotDetection'
 
    Cgoit\LeadsOptinBundle\:
       resource: ../src/*

--- a/src/Controller/Module/LeadsOptInModule.php
+++ b/src/Controller/Module/LeadsOptInModule.php
@@ -55,12 +55,14 @@ class LeadsOptInModule extends AbstractFrontendModuleController
 
     public const TYPE = 'leadsoptin';
 
+    private readonly ModuleBotDetection $botDetection;
+
     public function __construct(
         private readonly NotificationCenter $notificationCenter,
         private readonly Connection $db,
         private readonly StringParser $stringParser,
-        private readonly ModuleBotDetection $botDetection,
     ) {
+        $this->botDetection = new ModuleBotDetection();
     }
 
     protected function getResponse(Template $template, ModuleModel $model, Request $request): Response

--- a/src/Controller/Module/LeadsOptInModule.php
+++ b/src/Controller/Module/LeadsOptInModule.php
@@ -58,6 +58,7 @@ class LeadsOptInModule extends AbstractFrontendModuleController
         private readonly NotificationCenter $notificationCenter,
         private readonly Connection $db,
         private readonly StringParser $stringParser,
+        private readonly ModuleBotDetection $botDetection,
     ) {
     }
 
@@ -66,7 +67,7 @@ class LeadsOptInModule extends AbstractFrontendModuleController
         $token = Input::get('token');
         $template->errorMessage = $model->leadOptInErrorMessage;
 
-        if (!$token) {
+        if (!$token || $this->botDetection->checkBotAllTests()) {
             $template->isError = true;
 
             return $template->getResponse();

--- a/src/Controller/Module/LeadsOptInModule.php
+++ b/src/Controller/Module/LeadsOptInModule.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Cgoit\LeadsOptinBundle\Controller\Module;
 
+use BugBuster\BotDetection\ModuleBotDetection;
 use Cgoit\LeadsOptinBundle\Trait\TokenTrait;
 use Cgoit\LeadsOptinBundle\Util\Constants;
 use Codefog\HasteBundle\Form\Form;
@@ -34,7 +35,6 @@ use Doctrine\DBAL\Connection;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Terminal42\NotificationCenterBundle\NotificationCenter;
-use BugBuster\BotDetection\ModuleBotDetection;
 
 /**
  * Provides the frontend module to handle the optin process.

--- a/src/Controller/Module/LeadsOptInModule.php
+++ b/src/Controller/Module/LeadsOptInModule.php
@@ -34,6 +34,7 @@ use Doctrine\DBAL\Connection;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Terminal42\NotificationCenterBundle\NotificationCenter;
+use BugBuster\BotDetection\ModuleBotDetection;
 
 /**
  * Provides the frontend module to handle the optin process.

--- a/src/Cron/PurgeCron.php
+++ b/src/Cron/PurgeCron.php
@@ -81,7 +81,7 @@ class PurgeCron
         }
 
         if (null !== $this->contaoCronLogger) {
-            $this->contaoCronLogger->info(sprintf('Purged %s leads from %s forms.', $deleted, \count($forms)));
+            $this->contaoCronLogger->info(\sprintf('Purged %s leads from %s forms.', $deleted, \count($forms)));
         }
     }
 

--- a/src/EventListener/DataContainer/Lead.php
+++ b/src/EventListener/DataContainer/Lead.php
@@ -50,7 +50,7 @@ class Lead
         return Image::getHtml(
             $iconPath.$icon,
             '',
-            'title="'.sprintf(
+            'title="'.\sprintf(
                 $GLOBALS['TL_LANG']['tl_lead']['optin_label'],
                 $row['optin_tstamp'] ? Date::parse(
                     $GLOBALS['TL_CONFIG']['datimFormat'],


### PR DESCRIPTION
### Description

In my experience, link checkers often trigger the double opt-in and the website visitor then receives a false error message. To prevent this, I have integrated bot detection.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other