### PR TITLE
fix: Handle RouteParametersException on e.g. news detail pages

### DIFF
--- a/src/Hook/ProcessFormDataHook.php
+++ b/src/Hook/ProcessFormDataHook.php
@@ -108,6 +108,7 @@ class ProcessFormDataHook
 
         if ($formConfig['leadOptInTarget']) {
             $page = PageModel::findWithDetails($formConfig['leadOptInTarget']);
+            
             try {
                 $url = $page->getAbsoluteUrl();
             } catch (\Exception $e) {

--- a/src/Hook/ProcessFormDataHook.php
+++ b/src/Hook/ProcessFormDataHook.php
@@ -21,7 +21,6 @@ use Contao\Environment;
 use Contao\Form;
 use Contao\PageModel;
 use Doctrine\DBAL\Connection;
-use Exception;
 use Terminal42\NotificationCenterBundle\NotificationCenter;
 
 /**
@@ -111,7 +110,7 @@ class ProcessFormDataHook
             $page = PageModel::findWithDetails($formConfig['leadOptInTarget']);
             try {
                 $url = $page->getAbsoluteUrl();
-            } catch (Exception $e) {
+            } catch (\Exception $e) {
                 // Do nothing
             }
         }

--- a/src/Hook/ProcessFormDataHook.php
+++ b/src/Hook/ProcessFormDataHook.php
@@ -17,9 +17,11 @@ use Cgoit\LeadsOptinBundle\Trait\TokenTrait;
 use Cgoit\LeadsOptinBundle\Util\Constants;
 use Codefog\HasteBundle\StringParser;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsHook;
+use Contao\Environment;
 use Contao\Form;
 use Contao\PageModel;
 use Doctrine\DBAL\Connection;
+use Exception;
 use Terminal42\NotificationCenterBundle\NotificationCenter;
 
 /**
@@ -103,13 +105,17 @@ class ProcessFormDataHook
      */
     private function generateOptInUrl(string $token, array $formConfig): string
     {
-        $page = $GLOBALS['objPage'];
+        $url = Environment::get('uri');
 
         if ($formConfig['leadOptInTarget']) {
             $page = PageModel::findWithDetails($formConfig['leadOptInTarget']);
+            try {
+                $url = $page->getAbsoluteUrl();
+            } catch (Exception $e) {
+                // Do nothing
+            }
         }
 
-        $url = $page->getAbsoluteUrl();
         $parameter = '?token='.$token;
 
         return $url.$parameter;

--- a/src/Hook/ProcessFormDataHook.php
+++ b/src/Hook/ProcessFormDataHook.php
@@ -111,13 +111,17 @@ class ProcessFormDataHook
 
             try {
                 $url = $page->getAbsoluteUrl();
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 // Do nothing
             }
         }
 
-        $parameter = '?token='.$token;
+        $parameter = 'token='.$token;
 
-        return $url.$parameter;
+        $urlParts = explode('#', (string) $url, 2);
+        $url = $urlParts[0].(str_contains($urlParts[0], '?') ? '&' : '?').$parameter;
+        $hash = isset($urlParts[1]) ? '#'.$urlParts[1] : '';
+
+        return $url.$hash;
     }
 }

--- a/src/Hook/ProcessFormDataHook.php
+++ b/src/Hook/ProcessFormDataHook.php
@@ -108,7 +108,7 @@ class ProcessFormDataHook
 
         if ($formConfig['leadOptInTarget']) {
             $page = PageModel::findWithDetails($formConfig['leadOptInTarget']);
-            
+
             try {
                 $url = $page->getAbsoluteUrl();
             } catch (\Exception $e) {


### PR DESCRIPTION
If you integrate a form into a news article, the generation of the URL does not work correctly: Either the URL of the news detail page is generated without the alias of the news article or a `Contao\RouteParametersException` is thrown if the option "Element required" is activated on the news detail page.
Therefore, my suggestion is to get the OptInUrl by default via the `Contao\Environment::get('uri');` instead.